### PR TITLE
Add optimistic update capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,22 @@ export default createStore(reducers, {}, [
 ]);
 ```
 
-To use the middleware, dispatch a promise as the `payload` of the action and specify a `types` array.
+To use the middleware, dispatch a promise within the `payload` of the action and specify a `types` array. You may pass an optional `data` object. This is dispatched from the pending action and is useful for optimistic updates.
 
 The pending action is dispatched immediately. The fulfilled action is dispatched only if the promise is resolved, e.g., if it was successful; and the rejected action is dispatched only if the promise is rejected, e.g., if an error occurred.
 
 ```js
-export function myAsyncActionCreator() {
+export function myAsyncActionCreator(data) {
   return {
     types: [
       'ACTION_PENDING',
       'ACTION_FULFILLED',
       'ACTION_REJECTED'
     ],
-    payload: doSomethingAyncAndReturnPromise()
+    payload: {
+      promise: doSomethingAyncAndReturnPromise(data),
+      data: data
+    }
   };
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export default function promiseMiddleware() {
     }
 
     const { types } = action;
-    const promise = action.payload;
+    const { promise, data } = action.payload;
     const [ PENDING, FULFILLED, REJECTED ] = types;
 
     /**
@@ -15,7 +15,8 @@ export default function promiseMiddleware() {
      * reducer that an async action has been dispatched.
      */
     next({
-      type: PENDING
+      type: PENDING,
+      payload: data
     });
 
     /**

--- a/src/isPromise.js
+++ b/src/isPromise.js
@@ -1,3 +1,5 @@
 export default function isPromise(value) {
-  return value && typeof value.then === 'function';
+  if (value !== null && typeof value === 'object') {
+    return value.promise && typeof value.promise.then === 'function';
+  }
 }


### PR DESCRIPTION
This moves the promise into the payload option to also allow passing the data object. This breaks the API, up to you how you want to handle that. I can either add support for the both scenarios or we can drop the previous method. 