### PR TITLE
Add error parameter to action in case of error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ export default function promiseMiddleware() {
       }),
       error => next({
         payload: error,
+        error: true,
         type: REJECTED
       })
     );


### PR DESCRIPTION
It may be nice that the middleware adds "error: true" to the action in case of error. See https://github.com/acdlite/flux-standard-action