### PR TITLE
Default promise types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -14,23 +14,19 @@ First, import the middleware and include it in `applyMiddleware` when creating t
 import promiseMiddleware from 'redux-promise-middleware';
 
 composeStoreWithMiddleware = applyMiddleware(
-  promiseMiddleware
+  promiseMiddleware()
 )(createStore);
 
 ```
 
-To use the middleware, dispatch a promise within the `payload` of the action and specify a `types` array. You may pass an optional `data` object. This is dispatched from the pending action and is useful for optimistic updates.
+To use the middleware, dispatch a promise within the `payload` of the action and specify a `type` string. You may pass an optional `data` object. This is dispatched from the pending action and is useful for optimistic updates.
 
-The pending action is dispatched immediately. The fulfilled action is dispatched only if the promise is resolved, e.g., if it was successful; and the rejected action is dispatched only if the promise is rejected, e.g., if an error occurred.
+The pending action is dispatched immediately with the original type string and a suffix of `_PENDING`. The fulfilled action is dispatched only if the promise is resolved, e.g., if it was successful; and the rejected action is dispatched only if the promise is rejected, e.g., if an error occurred. The fulfilled and rejected suffixes are `_FULFILLED` and `_REJECTED` respectively.
 
 ```js
 export function myAsyncActionCreator(data) {
   return {
-    type: [
-      'ACTION_PENDING',
-      'ACTION_FULFILLED',
-      'ACTION_REJECTED'
-    ],
+    type: 'ACTION',
     payload: {
       promise: doSomethingAsyncAndReturnPromise(data),
       data: data
@@ -40,6 +36,35 @@ export function myAsyncActionCreator(data) {
 ```
 
 The middleware returns a [FSA compliant](https://github.com/acdlite/flux-standard-action) action for both rejected and resolved/fulfilled promises. In the case of a rejected promise, an `error` is returned.
+
+## Type Suffix Configuration
+
+When adding the middleware to your middleware composition layer, you can supply an optional options object. This object accepts an array of suffix strings that can be used instead of the default `['PENDING', 'REJECTED', 'FULFILLED']` with a key of `promiseTypeSuffixes`.
+
+```js
+applyMiddleware(
+  promiseMiddleware({
+    promiseTypeSuffixes: ['START', 'ERROR', 'SUCCESS']
+  })
+)
+```
+
+Alternatively, you can supply the same options at the action level inside the meta options that will change these suffixes on a per action type basis.
+
+```js
+export function myAsyncActionCreator(data) {
+  return {
+    type: 'ACTION',
+    payload: {
+      promise: doSomethingAsyncAndReturnPromise(data),
+      data: data
+    },
+    meta: {
+      promiseTypeSuffixes: ['WAIT', '!@£$', 'YAY']
+    }
+  };
+}
+```
 
 ---
 Licensed MIT. Copyright 2015 Patrick Burtchaell.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ The middleware returns a [FSA compliant](https://github.com/acdlite/flux-standar
 
 ## Type Suffix Configuration
 
-When adding the middleware to your middleware composition layer, you can supply an optional options object. This object accepts an array of suffix strings that can be used instead of the default `['PENDING', 'REJECTED', 'FULFILLED']` with a key of `promiseTypeSuffixes`.
+When adding the middleware to your middleware composition layer, you can supply an optional options object. This object accepts an array of suffix strings that can be used instead of the default `['PENDING', 'FULFILLED', 'REJECTED']` with a key of `promiseTypeSuffixes`.
 
 ```js
 applyMiddleware(
   promiseMiddleware({
-    promiseTypeSuffixes: ['START', 'ERROR', 'SUCCESS']
+    promiseTypeSuffixes: ['START', 'SUCCESS', 'ERROR']
   })
 )
 ```
@@ -60,7 +60,7 @@ export function myAsyncActionCreator(data) {
       data: data
     },
     meta: {
-      promiseTypeSuffixes: ['WAIT', '!@£$', 'YAY']
+      promiseTypeSuffixes: ['WAIT', 'YAY', '!@£$']
     }
   };
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The pending action is dispatched immediately. The fulfilled action is dispatched
 ```js
 export function myAsyncActionCreator(data) {
   return {
-    types: [
+    type: [
       'ACTION_PENDING',
       'ACTION_FULFILLED',
       'ACTION_REJECTED'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-promise-middleware",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Redux middleware for handling promises",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-promise-middleware",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "description": "Redux middleware for handling promises",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "eslint": "^0.24.1",
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.7.0"
+  },
+  "peerDependencies": {
+    "redux": "^2.0.0 || ^3.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function promiseMiddleware(config={}) {
       next({
         type: `${type}_${PENDING}`,
         payload: data,
-        meta
+        ...meta || {}
       });
 
       /**
@@ -32,13 +32,13 @@ export default function promiseMiddleware(config={}) {
         payload => next({
           type: `${type}_${FULFILLED}`,
           payload,
-          meta,
+          ...meta || {},
         }),
         error => next({
           type: `${type}_${REJECTED}`,
           payload: error,
           error: true,
-	  meta
+          ...meta || {}
         })
       );
     };

--- a/src/index.js
+++ b/src/index.js
@@ -2,43 +2,45 @@ import isPromise from './isPromise';
 
 const defaultTypes = ['PENDING', 'FULFILLED', 'REJECTED']
 
-export default function promiseMiddleware(config) {
+export default function promiseMiddleware(config={}) {
   const promiseTypes = config.promiseTypes || defaultTypes;
-  return next => action => {
-    if (!isPromise(action.payload)) {
-      return next(action);
-    }
+  return () => {
+    return next => action => {
+      if (!isPromise(action.payload)) {
+        return next(action);
+      }
 
-    const { type, payload, meta } = action;
-    const { promise, data } = payload;
-    const [ PENDING, FULFILLED, REJECTED ] = meta.promiseTypes || promiseTypes
+      const { type, payload, meta={} } = action;
+      const { promise, data } = payload;
+      const [ PENDING, FULFILLED, REJECTED ] = meta.promiseTypes || promiseTypes;
 
-    /**
-     * Dispatch the first async handler. This tells the
-     * reducer that an async action has been dispatched.
-     */
-    next({
-      type: `${type}_${PENDING}`,
-      payload: data,
-      meta
-    });
-
-    /**
-     * Return either the fulfilled action object or the rejected
-     * action object.
-     */
-    return promise.then(
-      payload => next({
-        type: `${type}_${FULFILLED}`,
-        payload,
-        meta,
-      }),
-      error => next({
-        type: `${type}_${REJECTED}`,
-        payload: error,
-        error: true,
+     /**
+      * Dispatch the first async handler. This tells the
+      * reducer that an async action has been dispatched.
+      */
+      next({
+        type: `${type}_${PENDING}`,
+        payload: data,
         meta
-      })
-    );
-  };
+      });
+
+      /**
+       * Return either the fulfilled action object or the rejected
+       * action object.
+       */
+      return promise.then(
+        payload => next({
+          type: `${type}_${FULFILLED}`,
+          payload,
+          meta,
+        }),
+        error => next({
+          type: `${type}_${REJECTED}`,
+          payload: error,
+          error: true,
+	  meta
+        })
+      );
+    };
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import isPromise from './isPromise';
 
-const defaultTypes = ['PENDING', 'FULFILLED', 'REJECTED']
+const defaultTypes = ['PENDING', 'FULFILLED', 'REJECTED'];
 
 export default function promiseMiddleware(config={}) {
   const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypes;
@@ -21,7 +21,7 @@ export default function promiseMiddleware(config={}) {
       next({
         type: `${type}_${PENDING}`,
         payload: data,
-        ...meta ? { meta } : {},
+        ...meta ? { meta } : {}
       });
 
       /**
@@ -29,18 +29,18 @@ export default function promiseMiddleware(config={}) {
        * action object.
        */
       return promise.then(
-        payload => next({
+        payload => next({ // eslint-disable-line no-shadow
           payload,
           type: `${type}_${FULFILLED}`,
-          ...meta ? { meta } : {},
+          ...meta ? { meta } : {}
         }),
         error => next({
           payload: error,
           error: true,
           type: `${type}_${REJECTED}`,
-          ...meta ? { meta } : {},
+          ...meta ? { meta } : {}
         })
       );
     };
-  }
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,24 @@
 import isPromise from './isPromise';
 
-export default function promiseMiddleware() {
+const defaultTypes = ['PENDING', 'FULFILLED', 'REJECTED']
+
+export default function promiseMiddleware(config) {
+  const promiseTypes = config.promiseTypes || defaultTypes;
   return next => action => {
     if (!isPromise(action.payload)) {
       return next(action);
     }
 
-    const { type, meta } = action;
-    const { promise, data } = action.payload;
-    const [ PENDING, FULFILLED, REJECTED ] = type;
+    const { type, payload, meta } = action;
+    const { promise, data } = payload;
+    const [ PENDING, FULFILLED, REJECTED ] = meta.promiseTypes || promiseTypes
 
     /**
      * Dispatch the first async handler. This tells the
      * reducer that an async action has been dispatched.
      */
     next({
-      type: PENDING,
+      type: `${type}_${PENDING}`,
       payload: data,
       meta
     });
@@ -26,12 +29,12 @@ export default function promiseMiddleware() {
      */
     return promise.then(
       payload => next({
-        type: FULFILLED,
+        type: `${type}_${FULFILLED}`,
         payload,
-        meta
+        meta,
       }),
       error => next({
-        type: REJECTED,
+        type: `${type}_${REJECTED}`,
         payload: error,
         error: true,
         meta

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export default function promiseMiddleware(config={}) {
 
       const { type, payload, meta } = action;
       const { promise, data } = payload;
-      const [ PENDING, FULFILLED, REJECTED ] = meta.promiseTypes || promiseTypes;
+      const [ PENDING, FULFILLED, REJECTED ] = (meta || {}).promiseTypes || promiseTypes;
 
      /**
       * Dispatch the first async handler. This tells the

--- a/src/index.js
+++ b/src/index.js
@@ -31,9 +31,10 @@ export default function promiseMiddleware() {
         meta
       }),
       error => next({
+        type: REJECTED,
         payload: error,
         error: true,
-        type: REJECTED
+        meta
       })
     );
   };

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ export default function promiseMiddleware() {
       return next(action);
     }
 
-    const { types, meta } = action;
+    const { type, meta } = action;
     const { promise, data } = action.payload;
     const [ PENDING, FULFILLED, REJECTED ] = type;
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ export default function promiseMiddleware(config={}) {
         return next(action);
       }
 
-      const { type, payload, meta={} } = action;
+      const { type, payload, meta } = action;
       const { promise, data } = payload;
       const [ PENDING, FULFILLED, REJECTED ] = meta.promiseTypes || promiseTypes;
 
@@ -21,7 +21,7 @@ export default function promiseMiddleware(config={}) {
       next({
         type: `${type}_${PENDING}`,
         payload: data,
-        ...meta || {}
+        ...meta ? { meta } : {},
       });
 
       /**
@@ -30,15 +30,15 @@ export default function promiseMiddleware(config={}) {
        */
       return promise.then(
         payload => next({
-          type: `${type}_${FULFILLED}`,
           payload,
-          ...meta || {},
+          type: `${type}_${FULFILLED}`,
+          ...meta ? { meta } : {},
         }),
         error => next({
-          type: `${type}_${REJECTED}`,
           payload: error,
           error: true,
-          ...meta || {}
+          type: `${type}_${REJECTED}`,
+          ...meta ? { meta } : {},
         })
       );
     };

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export default function promiseMiddleware() {
 
     const { types, meta } = action;
     const { promise, data } = action.payload;
-    const [ PENDING, FULFILLED, REJECTED ] = types;
+    const [ PENDING, FULFILLED, REJECTED ] = type;
 
     /**
      * Dispatch the first async handler. This tells the

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import isPromise from './isPromise';
 const defaultTypes = ['PENDING', 'FULFILLED', 'REJECTED']
 
 export default function promiseMiddleware(config={}) {
-  const promiseTypes = config.promiseTypes || defaultTypes;
+  const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypes;
   return () => {
     return next => action => {
       if (!isPromise(action.payload)) {
@@ -12,7 +12,7 @@ export default function promiseMiddleware(config={}) {
 
       const { type, payload, meta } = action;
       const { promise, data } = payload;
-      const [ PENDING, FULFILLED, REJECTED ] = (meta || {}).promiseTypes || promiseTypes;
+      const [ PENDING, FULFILLED, REJECTED ] = (meta || {}).promiseTypeSuffixes || promiseTypeSuffixes;
 
      /**
       * Dispatch the first async handler. This tells the


### PR DESCRIPTION
Resolves #1.

Automatically assumes promise types of PENDING, FULFILLED, REJECTED.
Initial action now only needs to contain a single type.

Can customise the types at the middleware level:

```js
applyMiddleware(
  promiseMiddleware({
    promiseTypes: ['WAIT', 'YAY', 'BUGGER']
  })
```

breaking change: when adding the middleware, it must be invoked even if you don't supply custom types:
```js
applyMiddleware(
  promiseMiddleware()
...
// defaults to PENDING, FULFILLED, REJECTED
```

or override both at dispatch with the same payload as before, just add the types array to you meta object:
```js
dispatch({
  type, payload, meta: {
    promiseTypes: [ 'MAYBE', 'AWESOME', '*!@£' ]
  }
})
```