### PR TITLE
added customisable payload for promise resolution to fulfilled action

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default function promiseMiddleware(config={}) {
       return promise.then(
         resolved => next({ // eslint-disable-line no-shadow
           type: `${type}_${FULFILLED}`,
-          ...resolved.meta ? resolved : {
+          ...resolved.meta || resolved.payload ? resolved : {
             payload: resolved,
             ...meta && { meta }
           }

--- a/src/index.js
+++ b/src/index.js
@@ -29,15 +29,17 @@ export default function promiseMiddleware(config={}) {
        * action object.
        */
       return promise.then(
-        payload => next({ // eslint-disable-line no-shadow
-          payload,
+        resolved => next({ // eslint-disable-line no-shadow
           type: `${type}_${FULFILLED}`,
-          ...meta ? { meta } : {}
+          ...resolved.meta ? resolved : {
+            resolved: payload,
+            ...meta ? { meta } : {}
+          }
         }),
         error => next({
+          type: `${type}_${REJECTED}`,
           payload: error,
           error: true,
-          type: `${type}_${REJECTED}`,
           ...meta ? { meta } : {}
         })
       );

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function promiseMiddleware(config={}) {
       next({
         type: `${type}_${PENDING}`,
         payload: data,
-        ...meta ? { meta } : {}
+        ...meta && { meta }
       });
 
       /**
@@ -33,14 +33,14 @@ export default function promiseMiddleware(config={}) {
           type: `${type}_${FULFILLED}`,
           ...resolved.meta ? resolved : {
             payload: resolved,
-            ...meta ? { meta } : {}
+            ...meta && { meta }
           }
         }),
         error => next({
           type: `${type}_${REJECTED}`,
           payload: error,
           error: true,
-          ...meta ? { meta } : {}
+          ...meta && { meta }
         })
       );
     };

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default function promiseMiddleware(config={}) {
         resolved => next({ // eslint-disable-line no-shadow
           type: `${type}_${FULFILLED}`,
           ...resolved.meta ? resolved : {
-            resolved: payload,
+            payload: resolved,
             ...meta ? { meta } : {}
           }
         }),


### PR DESCRIPTION
When the promise resolves an object with a `meta` property,
this middleware will merge the resolved object into the fulfilled action and ignore the original meta
instead of the existing functionality of supplying the resolved object as just the payload and keeping the original meta

e.g.

Current behaviour is still preserved
```js
function myActionCreator(){
  return {
    type: 'ACTION',
    payload: {
      promise: Promise.resolve({ foo: 'bar' }) // resolve payload
    },
    meta: { herp: 'derp' }
  }
}
/*
will eventually dispatch
{
  type: 'ACTION_FULFILLED',
  payload: { foo: 'bar' },
  meta: { herp: 'derp' }
}
*/
```

But now can overwrite previous meta:

```js
function myActionCreator(){
  return {
    type: 'ACTION',
    payload: {
      promise: Promise.resolve({ // resolve full action
        payload: {foo: 'bar'}, // note payload here
        meta: {new: 'meta'} // and also meta here
      })
    },
    meta: { herp: 'derp' }
  }
}
/*
will eventually dispatch
{
  type: 'ACTION_FULFILLED',
  payload: { foo: 'bar' },
  meta: { new: 'meta' }
}
*/
```