### PR TITLE
added check for thunk before resolving as payload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,9 @@ export default function promiseMiddleware(config = {}) {
         ...meta && { meta }
       });
 
+      const isActionOrThunk = resolved =>
+        typeof resolved === 'function' || resolved.meta || resolved.payload;
+
       /**
        * Return either the fulfilled action object or the rejected
        * action object.
@@ -34,7 +37,7 @@ export default function promiseMiddleware(config = {}) {
       return promise.then(
         (resolved={}) => dispatch({
           type: `${type}_${FULFILLED}`,
-          ...resolved.meta || resolved.payload ? resolved : {
+          ...isActionOrThunk(resolved) ? resolved : {
             ...resolved && { payload: resolved },
             ...meta && { meta }
           }


### PR DESCRIPTION
After replacing the next calls with dispatch, the resolved payload can go through the whole middleware stack which is cool
```js
const action = () => ({
 type: "FOO",
 payload: {
  promise: Promise.resolve({ payload: 'goes through middleware earlier in stack' })
 }
})
```

But we assume these resolved values are either a payload or an action, so this change also checks for thunks or well... functions... if we find a function has been resolved, we dispatch it.. instead of only checking for payload or meta and then trying to dispatch the resolved value as a payload.

So now this should work too:
```js
const action = () => ({
 type: "FOO",
 payload: {
  promise: Promise.resolve((dispatch, getState) => { // resolve a thunk!
   dispatch({ payload: 'goes through middleware earlier in stack' })
   dispatch({ more: "things" })
   dispatch(updateRoute('/happy-composition-town'))
   doSomethingNaughtAfterDispatchingEverything(getState())
  })
 }
})
```