### PR TITLE
correctly checking for thunk and doing same for reject

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,26 +27,28 @@ export default function promiseMiddleware(config = {}) {
         ...meta && { meta }
       });
 
-      const isActionOrThunk = resolved =>
-        typeof resolved === 'function' || resolved.meta || resolved.payload;
+      const isAction = resolved => resolved.meta || resolved.payload;
 
+      const isThunk = resolved => typeof resolved === 'function';
       /**
        * Return either the fulfilled action object or the rejected
        * action object.
        */
       return promise.then(
-        (resolved = {}) => dispatch({
+        (resolved={}) => isThunk(resolved) ? dispatch(resolved) : dispatch({
           type: `${type}_${FULFILLED}`,
-          ...isActionOrThunk(resolved) ? resolved : {
+          ...isAction(resolved) ? resolved : {
             ...resolved && { payload: resolved },
             ...meta && { meta }
           }
         }),
-        error => dispatch({
+        (resolved={}) => isThunk(resolved) ? dispatch(resolved) : dispatch({
           type: `${type}_${REJECTED}`,
-          payload: error,
-          error: true,
-          ...meta && { meta }
+          ...isAction(resolved) ? resolved : {
+            error: true,
+            ...resolved && { payload: resolved },
+            ...meta && { meta }
+          }
         })
       );
     };


### PR DESCRIPTION
Previous update to 2.2.2 was actually broken.. my mistake! Was attempting to merge the thunk function into the object with type! Arg!

This PR fixes that logic and also adds the same process to REJECT actions.

One down side, when your promise resolves a thunk, you need to manually add the action.type to the object you dispatch. 