### PR TITLE
bind thunk to action when resolving thunk and made checks more explicit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,10 @@ export default function promiseMiddleware(config = {}) {
 
       const isAction = resolved => resolved.meta || resolved.payload;
       const isThunk = resolved => typeof resolved === 'function';
-      const getResolveAction = (error) => ({
-        type: `${type}_${error ? REJECTED : FULFILLED}`,
+      const getResolveAction = (isError) => ({
+        type: `${type}_${isError ? REJECTED : FULFILLED}`,
         ...!!meta && { meta },
-        ...!!error && { error: true }
+        ...!!isError && { error: true }
       });
 
       /**

--- a/src/index.js
+++ b/src/index.js
@@ -23,33 +23,43 @@ export default function promiseMiddleware(config = {}) {
       */
       next({
         type: `${type}_${PENDING}`,
-        ...data && { payload: data },
-        ...meta && { meta }
+        ...!!data && { payload: data },
+        ...!!meta && { meta }
       });
 
       const isAction = resolved => resolved.meta || resolved.payload;
-
       const isThunk = resolved => typeof resolved === 'function';
+      const getResolveAction = (error) => ({
+        type: `${type}_${error ? REJECTED : FULFILLED}`,
+        ...!!meta && { meta },
+        ...!!error && { error: true }
+      });
+
       /**
-       * Return either the fulfilled action object or the rejected
-       * action object.
+       * Re-dispatch one of:
+       *  1. a thunk, bound to a resolved/rejected object containing ?meta and type
+       *  2. the resolved/rejected object, if it looks like an action, merged into action
+       *  3. a resolve/rejected action with the resolve/rejected object as a payload
        */
-      return promise.then(
-        (resolved={}) => isThunk(resolved) ? dispatch(resolved) : dispatch({
-          type: `${type}_${FULFILLED}`,
-          ...isAction(resolved) ? resolved : {
-            ...resolved && { payload: resolved },
-            ...meta && { meta }
-          }
-        }),
-        (resolved={}) => isThunk(resolved) ? dispatch(resolved) : dispatch({
-          type: `${type}_${REJECTED}`,
-          ...isAction(resolved) ? resolved : {
-            error: true,
-            ...resolved && { payload: resolved },
-            ...meta && { meta }
-          }
-        })
+      promise.then(
+        (resolved={}) => {
+          const resolveAction = getResolveAction();
+          dispatch(isThunk(resolved) ? resolved.bind(null, resolveAction) : {
+            ...resolveAction,
+            ...isAction(resolved) ? resolved : {
+              ...!!resolved && { payload: resolved }
+            }
+          });
+        },
+        (rejected={}) => {
+          const resolveAction = getResolveAction(true);
+          dispatch(isThunk(rejected) ? rejected.bind(null, resolveAction) : {
+            ...resolveAction,
+            ...isAction(rejected) ? rejected : {
+              ...!!rejected && { payload: rejected }
+            }
+          });
+        },
       );
     };
   };


### PR DESCRIPTION
as discussed in https://github.com/pburtchaell/redux-promise-middleware/pull/31#issuecomment-160353593

I've also made the checks more explicit with bang bang.

Tested it locally on a project and all works fine, wasn't sure whether to refactor the resolve/reject blocks down as they're basically the same now.

We should really write more tests for all these use-cases but I'm just too lazy right now!