### PR TITLE
Returning action from middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,10 +41,10 @@ export default function promiseMiddleware(config = {}) {
        *  2. the resolved/rejected object, if it looks like an action, merged into action
        *  3. a resolve/rejected action with the resolve/rejected object as a payload
        */
-      promise.then(
+      action.payload.promise = promise.then(
         (resolved={}) => {
           const resolveAction = getResolveAction();
-          dispatch(isThunk(resolved) ? resolved.bind(null, resolveAction) : {
+          return dispatch(isThunk(resolved) ? resolved.bind(null, resolveAction) : {
             ...resolveAction,
             ...isAction(resolved) ? resolved : {
               ...!!resolved && { payload: resolved }
@@ -53,7 +53,7 @@ export default function promiseMiddleware(config = {}) {
         },
         (rejected={}) => {
           const resolveAction = getResolveAction(true);
-          dispatch(isThunk(rejected) ? rejected.bind(null, resolveAction) : {
+          return dispatch(isThunk(rejected) ? rejected.bind(null, resolveAction) : {
             ...resolveAction,
             ...isAction(rejected) ? rejected : {
               ...!!rejected && { payload: rejected }
@@ -61,6 +61,8 @@ export default function promiseMiddleware(config = {}) {
           });
         },
       );
+
+      return action;
     };
   };
 }


### PR DESCRIPTION
Redux [docs](http://redux.js.org/docs/api/Store.html#dispatch) state that store.dispatch should return the dispatched action.

So we should respect that API and return the dispatched action.

This raises a question around whether we should return the originally dispatched action created by the user, or our first `_PENDING` action -- as that's what gets passed through the chain. Also, other middleware may change this action and we should be returning their modifications... The standard is `return next(action)`... But this causes problems, as it doesn't allow a consumer to gain access to the later dispatched actions from the promise.

This PR now has our middleware return the original action that a consumer dispatches when our middleware intervenes. We also modify the promise contained in the action payload to be chained with our `.then` block -- allowing consumers to listen to the said promise and gain access to our _FULFILLED or _REJECTED dispatch calls.

```js
const action = store.dispatch(somePromiseActionCreator())
console.log(action) // the original action (not pending)
action.payload.promise.then(
  (nextAction) => console.log(nextAction) // either the _fulfilled or _rejected action object
)

// ...

const action = store.dispatch(normalAction())
console.log(action) // behaviour as normal, returning the action from the result of all other middleware
```
