### PR TITLE
Fix mutation of promise actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "babel": "^5.6.14",
     "babel-eslint": "^3.1.23",
     "chai": "^3.4.0",
-    "chai-as-promised": "^5.3.0",
     "eslint": "^0.24.1",
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel": "^5.6.14",
     "babel-eslint": "^3.1.23",
     "chai": "^3.4.0",
+    "chai-as-promised": "^5.3.0",
     "eslint": "^0.24.1",
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -41,36 +41,28 @@ export default function promiseMiddleware(config = {}) {
        *  2. the resolved/rejected object, if it looks like an action, merged into action
        *  3. a resolve/rejected action with the resolve/rejected object as a payload
        */
-      const newPromise = new Promise((resolve, reject) => {
-        action.payload.promise.then(
-          (resolved = {}) => {
-            const resolveAction = getResolveAction();
-            const result = dispatch(isThunk(resolved) ? resolved.bind(null, resolveAction) : {
-              ...resolveAction,
-              ...isAction(resolved) ? resolved : {
-                ...!!resolved && { payload: resolved }
-              }
-            });
-            resolve(result);
-          },
-          (rejected = {}) => {
-            const resolveAction = getResolveAction(true);
-            const error = dispatch(isThunk(rejected) ? rejected.bind(null, resolveAction) : {
-              ...resolveAction,
-              ...isAction(rejected) ? rejected : {
-                ...!!rejected && { payload: rejected }
-              }
-            });
-            reject(error);
-          }
-        );
-      });
+      action.payload.promise = promise.then(
+        (resolved = {}) => {
+          const resolveAction = getResolveAction();
+          return dispatch(isThunk(resolved) ? resolved.bind(null, resolveAction) : {
+            ...resolveAction,
+            ...isAction(resolved) ? resolved : {
+              ...!!resolved && { payload: resolved }
+            }
+          });
+        },
+        (rejected = {}) => {
+          const resolveAction = getResolveAction(true);
+          return dispatch(isThunk(rejected) ? rejected.bind(null, resolveAction) : {
+            ...resolveAction,
+            ...isAction(rejected) ? rejected : {
+              ...!!rejected && { payload: rejected }
+            }
+          });
+        },
+      );
 
-      return Object.assign({}, action, {
-        payload: Object.assign({}, action.payload, {
-          promise: newPromise,
-        }),
-      });
+      return action;
     };
   };
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,10 +1,12 @@
 import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { createStore, applyMiddleware } from 'redux';
 import configureStore from 'redux-mock-store';
 import promiseMiddleware from '../src/index';
 chai.use(sinonChai);
+chai.use(chaiAsPromised);
 
 describe('Redux Promise Middleware:', () => {
   const nextHandler = promiseMiddleware();
@@ -137,8 +139,10 @@ describe('Redux Promise Middleware:', () => {
       expect(lastMiddlewareModfies.spy).to.have.been.calledWith(pendingAction);
     });
 
-    it('returns the originally dispatched action', () => {
-      expect(store.dispatch(promiseAction)).to.eql(promiseAction);
+    it('should not mutate the originally dispatched action', () => {
+      const originalPromiseAction = Object.assign({}, promiseAction);
+      store.dispatch(promiseAction);
+      expect(promiseAction).to.eql(originalPromiseAction);
     });
 
     context('When Promise Rejects:', ()=> {
@@ -170,7 +174,7 @@ describe('Redux Promise Middleware:', () => {
       });
 
       it('re-dispatches rejected action with error and payload from error', async () => {
-        await store.dispatch(rejectingPromiseAction).payload.promise;
+        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -180,7 +184,7 @@ describe('Redux Promise Middleware:', () => {
           type: `${rejectingPromiseAction.type}_REJECTED`,
           error: true
         };
-        await store.dispatch(rejectingPromiseAction).payload.promise;
+        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -188,7 +192,7 @@ describe('Redux Promise Middleware:', () => {
         const metaData = { fake: 'data' };
         rejectingPromiseAction.meta = metaData;
         rejectedAction.meta = metaData;
-        await store.dispatch(rejectingPromiseAction).payload.promise;
+        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -202,7 +206,7 @@ describe('Redux Promise Middleware:', () => {
           error: true,
           ...newAction
         };
-        await store.dispatch(rejectingPromiseAction).payload.promise;
+        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -216,7 +220,7 @@ describe('Redux Promise Middleware:', () => {
           error: true,
           ...newAction
         };
-        await store.dispatch(rejectingPromiseAction).payload.promise;
+        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -230,7 +234,7 @@ describe('Redux Promise Middleware:', () => {
           dispatch({ ...action, foo: 'bar' });
         };
         rejectingPromiseAction.payload.promise = Promise.reject(thunkResolve);
-        await store.dispatch(rejectingPromiseAction).payload.promise;
+        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith({
           type: `${rejectingPromiseAction.type}_REJECTED`,
           error: true,
@@ -238,9 +242,9 @@ describe('Redux Promise Middleware:', () => {
         });
       });
 
-      it('returns action.payload.promise resolving the rejected action', async () => {
-        const resolving = await store.dispatch(rejectingPromiseAction).payload.promise;
-        expect(resolving).to.eql({
+      it('returns action.payload.promise rejecting the rejected action', async () => {
+        const rejecting = await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
+        expect(rejecting).to.eql({
           ...rejectedAction,
           ...lastMiddlewareModfiesObject
         });
@@ -252,7 +256,7 @@ describe('Redux Promise Middleware:', () => {
           promiseTypeSuffixes: [ '', '', customPrefix ]
         });
         rejectedAction.type = `${rejectingPromiseAction.type}_${customPrefix}`;
-        await store.dispatch(rejectingPromiseAction).payload.promise;
+        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -263,7 +267,7 @@ describe('Redux Promise Middleware:', () => {
         rejectedAction.type = `${rejectingPromiseAction.type}_${customPrefix}`;
         // FIXME: Test leak, should the promiseTypeSuffixes be in other actions?
         rejectedAction.meta = actionMeta;
-        await store.dispatch(rejectingPromiseAction).payload.promise;
+        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
     });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,12 +1,10 @@
 import chai, { expect } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { createStore, applyMiddleware } from 'redux';
 import configureStore from 'redux-mock-store';
 import promiseMiddleware from '../src/index';
 chai.use(sinonChai);
-chai.use(chaiAsPromised);
 
 describe('Redux Promise Middleware:', () => {
   const nextHandler = promiseMiddleware();
@@ -139,10 +137,8 @@ describe('Redux Promise Middleware:', () => {
       expect(lastMiddlewareModfies.spy).to.have.been.calledWith(pendingAction);
     });
 
-    it('should not mutate the originally dispatched action', () => {
-      const originalPromiseAction = Object.assign({}, promiseAction);
-      store.dispatch(promiseAction);
-      expect(promiseAction).to.eql(originalPromiseAction);
+    it('returns the originally dispatched action', () => {
+      expect(store.dispatch(promiseAction)).to.eql(promiseAction);
     });
 
     context('When Promise Rejects:', ()=> {
@@ -174,7 +170,7 @@ describe('Redux Promise Middleware:', () => {
       });
 
       it('re-dispatches rejected action with error and payload from error', async () => {
-        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
+        await store.dispatch(rejectingPromiseAction).payload.promise;
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -184,7 +180,7 @@ describe('Redux Promise Middleware:', () => {
           type: `${rejectingPromiseAction.type}_REJECTED`,
           error: true
         };
-        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
+        await store.dispatch(rejectingPromiseAction).payload.promise;
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -192,7 +188,7 @@ describe('Redux Promise Middleware:', () => {
         const metaData = { fake: 'data' };
         rejectingPromiseAction.meta = metaData;
         rejectedAction.meta = metaData;
-        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
+        await store.dispatch(rejectingPromiseAction).payload.promise;
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -206,7 +202,7 @@ describe('Redux Promise Middleware:', () => {
           error: true,
           ...newAction
         };
-        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
+        await store.dispatch(rejectingPromiseAction).payload.promise;
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -220,7 +216,7 @@ describe('Redux Promise Middleware:', () => {
           error: true,
           ...newAction
         };
-        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
+        await store.dispatch(rejectingPromiseAction).payload.promise;
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -234,7 +230,7 @@ describe('Redux Promise Middleware:', () => {
           dispatch({ ...action, foo: 'bar' });
         };
         rejectingPromiseAction.payload.promise = Promise.reject(thunkResolve);
-        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
+        await store.dispatch(rejectingPromiseAction).payload.promise;
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith({
           type: `${rejectingPromiseAction.type}_REJECTED`,
           error: true,
@@ -242,9 +238,9 @@ describe('Redux Promise Middleware:', () => {
         });
       });
 
-      it('returns action.payload.promise rejecting the rejected action', async () => {
-        const rejecting = await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
-        expect(rejecting).to.eql({
+      it('returns action.payload.promise resolving the rejected action', async () => {
+        const resolving = await store.dispatch(rejectingPromiseAction).payload.promise;
+        expect(resolving).to.eql({
           ...rejectedAction,
           ...lastMiddlewareModfiesObject
         });
@@ -256,7 +252,7 @@ describe('Redux Promise Middleware:', () => {
           promiseTypeSuffixes: [ '', '', customPrefix ]
         });
         rejectedAction.type = `${rejectingPromiseAction.type}_${customPrefix}`;
-        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
+        await store.dispatch(rejectingPromiseAction).payload.promise;
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
 
@@ -267,7 +263,7 @@ describe('Redux Promise Middleware:', () => {
         rejectedAction.type = `${rejectingPromiseAction.type}_${customPrefix}`;
         // FIXME: Test leak, should the promiseTypeSuffixes be in other actions?
         rejectedAction.meta = actionMeta;
-        await chai.assert.isRejected(store.dispatch(rejectingPromiseAction).payload.promise);
+        await store.dispatch(rejectingPromiseAction).payload.promise;
         expect(lastMiddlewareModfies.spy).to.have.been.calledWith(rejectedAction);
       });
     });


### PR DESCRIPTION
The promise middleware mutates `action.payload.promise` to be a promise that never rejects, which is nonintuitive and troublesome to debug.

```js
const myAwesomeAction = () => ({
  type: 'FOOBAR',
  payload: {
    promise: Promise.reject(),
  },
});

...
(in a React component with bound action creators):
doSomething() {
  this.props.actions.myAwesomeAction().then(null, () => {
    // this never gets run because the promise has already been overwritten to be always fulfilling
  });
}
```