### PR TITLE
Chaining actions with 'then' bug

### DIFF
--- a/test/chainingActionsTest.js
+++ b/test/chainingActionsTest.js
@@ -1,0 +1,26 @@
+import { applyMiddleware, createStore } from 'redux';
+import promiseMiddleware from '../src/index';
+import thunkMiddleware from 'redux-thunk';
+
+describe('Chaining actions:', () => {
+  it('should be "thenable" after dispatch', () => {
+    const reducer = (state = 0) => state;
+    const createStoreWithMiddleware = applyMiddleware(
+        thunkMiddleware,
+        promiseMiddleware
+    )(createStore);
+    const store = createStoreWithMiddleware(reducer);
+
+    const action = () =>
+      dispatch => {
+        const result = dispatch({
+          type: 'TYPE',
+          payload: { promise: Promise.resolve('foo') }
+        }).then(() => {
+            // On resolve
+        });
+        return result;
+      };
+    store.dispatch(action());
+  });
+});

--- a/test/chainingActionsTest.js
+++ b/test/chainingActionsTest.js
@@ -4,23 +4,22 @@ import thunkMiddleware from 'redux-thunk';
 
 describe('Chaining actions:', () => {
   it('should be "thenable" after dispatch', () => {
-    const reducer = (state = 0) => state;
+    const reducer = (state = 0) => state; // Dummy reducer
     const createStoreWithMiddleware = applyMiddleware(
         thunkMiddleware,
         promiseMiddleware
     )(createStore);
     const store = createStoreWithMiddleware(reducer);
 
-    const action = () =>
+    const action = () => // Thunk action creator
       dispatch => {
-        const result = dispatch({
+        return dispatch({
           type: 'TYPE',
-          payload: { promise: Promise.resolve('foo') }
+          payload: { promise: Promise.resolve('foo') } // Dummy promise
         }).then(() => {
             // On resolve
         });
-        return result;
       };
-    store.dispatch(action());
+    store.dispatch(action()); // Call action creator and dispatch
   });
 });

--- a/test/chainingActionsTest.js
+++ b/test/chainingActionsTest.js
@@ -12,14 +12,13 @@ describe('Chaining actions:', () => {
     const store = createStoreWithMiddleware(reducer);
 
     const action = () => // Thunk action creator
-      dispatch => {
-        return dispatch({
+      dispatch =>
+        dispatch({
           type: 'TYPE',
           payload: { promise: Promise.resolve('foo') } // Dummy promise
         }).then(() => {
             // On resolve
         });
-      };
     store.dispatch(action()); // Call action creator and dispatch
   });
 });


### PR DESCRIPTION
I might be missing something, but according to [this](https://github.com/pburtchaell/redux-promise-middleware/releases/tag/3.0.0), you should be able to chain actions like this: 
``` javascript
const action = () => // Thunk action creator                                                                                                                                  
       dispatch => {
         return dispatch({                                                                                                                                                         
           type: 'TYPE',                                                                                                                                                           
           payload: { promise: Promise.resolve('foo') } // Dummy promise                                                                                                           
         }).then(({ value, action }) => { 
             // On resolve
         });
      };
```
However, I get a `dispatch(...).then is not a function` error.