### PR TITLE
updated .npmignore to exclude node_modules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,6 @@ docs/
 .travis.yml
 CONTRIBUTING.md
 Makefile
+.npmignore
+node_modules
+jspm_packages


### PR DESCRIPTION
`redux-promise-middleware@3.0.1` has `node_modules` directory published inside it (which includes `history@2.0.1`). This causes an issue when trying to `npm shrinkwrap`: 
`extraneous: history@2.0.1 /Users/rotemm/git/github/wix-one-app/node_modules/redux-promise-middleware/node_modules/history`
