### PR TITLE
Fix dropping errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,24 +107,19 @@ export default function promiseMiddleware(config = {}) {
        *   }
        * }
        */
-      return new Promise((resolve, reject) => {
-        promise.then(
-          (value = null) => {
-            const resolvedAction = getAction(value, false);
-            dispatch(resolvedAction);
-            resolve({ value, action: resolvedAction });
-
-            return;
-          },
-          (reason = null) => {
-            const rejectedAction = getAction(reason, true);
-            dispatch(rejectedAction);
-            reject({ reason, action: rejectedAction });
-
-            return;
-          }
-        );
-      });
+      return promise.then(
+        (value = null) => {
+          const resolvedAction = getAction(value, false);
+          dispatch(resolvedAction);
+          return { value, action: resolvedAction };
+        },
+        (reason = null) => {
+          const rejectedAction = getAction(reason, true);
+          dispatch(rejectedAction);
+          const rejection = { reason, action: rejectedAction };
+          throw rejection;
+        }
+      );
     };
   };
 }


### PR DESCRIPTION
Due to a misuse of promises, the promise returned by the middleware will be stuck in a pending state if the call to `dispatch(____Action)` fails. This most commonly occurs when there is an error in a reducer (or sometimes in a `render()` call).

There's no need to create a new promise and imperatively resolve/reject the promise; the `then` combinator is made for this pattern.

To reproduce the bug, see the new test case.