### PR TITLE
Add UMD build tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "start": "babel-node examples/server.js",
     "pretest": "npm run lint",
     "test": "make test_coverage",
-    "build": "`npm bin`/babel src -d dist",
+    "build": "npm run build:commonjs & npm run build:umd & npm run build:umd:min",
+    "build:commonjs": "`npm bin`/babel src -d dist",
+    "build:umd": "`npm bin`/webpack dist/ReduxPromiseMiddleware.js",
+    "build:umd:min": "NODE_ENV=production `npm bin`/webpack dist/ReduxPromiseMiddleware.min.js",
     "prepublish": "npm test && npm run build",
     "lint": "`npm bin`/eslint src/**/*.js examples/**/*.js test/**/*.js"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const defaultTypes = ['PENDING', 'FULFILLED', 'REJECTED'];
  * @description
  * @returns {function} thunk
  */
-export default function promiseMiddleware(config = {}) {
+module.exports = function promiseMiddleware(config = {}) {
   const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypes;
 
   return ref => {
@@ -144,4 +144,4 @@ export default function promiseMiddleware(config = {}) {
       return promise.then(handleFulfill, handleReject);
     };
   };
-}
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,32 @@
+var webpack = require('webpack');
+
+var config = {
+  entry: './src/index',
+
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel'], exclude: /node_modules/ }
+    ]
+  },
+
+  output: {
+    library: 'ReduxPromiseMiddleware',
+    libraryTarget: 'umd'
+  },
+
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin()
+  ]
+};
+
+if (process.env.NODE_ENV === 'production') {
+  config.plugins.push(
+    new webpack.optimize.UglifyJsPlugin({
+      compressor: {
+        warnings: false
+      }
+    })
+  );
+}
+
+module.exports = config;


### PR DESCRIPTION
Add UMD (Universal Module Definition) build tasks.

Implementation adapted from reactjs/react-router-redux@ad0d41d.

Modified module definition to work around webpack/webpack#706.

Thanks for considering this!