### PR TITLE
Add spec demonstrating circular reference in error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,8 +90,7 @@ module.exports = function promiseMiddleware(config = {}) {
         const rejectedAction = getAction(reason, true);
         dispatch(rejectedAction);
 
-        const error = reason instanceof Error ? reason : new Error();
-
+        const error = new Error();
         error.reason = reason;
         error.action = rejectedAction;
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -462,5 +462,21 @@ describe('Redux Promise Middleware:', () => {
         done();
       }).catch(done);
     });
+
+    it('does not allow errors to contain circular references', done => {
+      const baseError = new Error('Base Error');
+
+      const actionDispatched = store.dispatch({
+        type: defaultPromiseAction.type,
+        payload: Promise.reject(baseError)
+      });
+
+      actionDispatched.catch(error => {
+        const { reason, action } = error;
+
+        expect(() => JSON.stringify(error)).to.not.throw(Error);
+        done();
+      }).catch(done);
+    });
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -445,7 +445,7 @@ describe('Redux Promise Middleware:', () => {
       });
     });
 
-    it('throws original rejected error instance', done => {
+    it('throws a new Error with Error#reason as the original error', done => {
       const baseError = new Error('Base Error');
 
       const actionDispatched = store.dispatch({
@@ -456,8 +456,25 @@ describe('Redux Promise Middleware:', () => {
       actionDispatched.catch(error => {
         const { reason, action } = error;
 
-        expect(reason).to.be.equal(baseError);
-        expect(action.payload).to.be.equal(baseError);
+        expect(error).to.not.equal(baseError);
+        expect(reason).to.equal(baseError);
+
+        done();
+      }).catch(done);
+    });
+
+    it('includes the rejected error in the payload when an error is thrown', done => {
+      const baseError = new Error('Base Error');
+
+      const actionDispatched = store.dispatch({
+        type: defaultPromiseAction.type,
+        payload: Promise.reject(baseError)
+      });
+
+      actionDispatched.catch(error => {
+        const { reason, action } = error;
+
+        expect(action.payload).to.equal(baseError);
 
         done();
       }).catch(done);


### PR DESCRIPTION
Currently, the implementation of `handleReject` is buggy since it contains a circular reference. This means that stringifying the error in any way is impossible. I noticed there was a spec which ensures that    `reason` is the same instance as the error itself. I do not think it is possible to keep this behavior without having a circular reference.

This is a major bug since it prevents many useful things:

- using redux-dev-tools
- printing an error

Let's discuss the best way to fix this bug. Personally, I think we should always create a new error, and assign the reason to be the original error.