### PR TITLE
Use default export syntax for better compatibility with typescript

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const defaultTypes = ['PENDING', 'FULFILLED', 'REJECTED'];
  * @description
  * @returns {function} thunk
  */
-module.exports = function promiseMiddleware(config = {}) {
+export default function promiseMiddleware(config = {}) {
   const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypes;
 
   return ref => {
@@ -140,4 +140,4 @@ module.exports = function promiseMiddleware(config = {}) {
       return promise.then(handleFulfill, handleReject);
     };
   };
-};
+}


### PR DESCRIPTION
Using this syntax makes the import syntax less ambiguous for certain transpilers (i.e. typescript). It also makes declaring type defintions possible while still using es6 import syntax. Therefore TS users can write:

```typescript
import reduxPromiseMiddleware from 'redux-promise-middleware';
```

as opposed to:

```typescript
import reduxPromiseMiddleware = require('redux-promise-middleware')
```

Even better, there is no change for Babel users! Only enhancements for TS users.