### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Redux promise middleware enables robust handling of async code in [Redux](http:/
 
 ## Docs and Help
 
-- [Guides](/docs/guides/)
-- [Introduction](/docs/introduction.md)
-- [Examples](/examples)
+- [Guides](./docs/guides/)
+- [Introduction](./docs/introduction.md)
+- [Examples](./examples)
 - [Releases](https://github.com/pburtchaell/redux-promise-middleware/releases)
-- [Upgrading versions](/UPGRADING.md)
+- [Upgrading versions](./UPGRADING.md)
 
 **Older versions:**
 


### PR DESCRIPTION
The URL's lead to github's `/` absolute path, for example: `github.com/docs/guides`.