### PR TITLE
Keep Ternary Operators on Single Line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,13 @@ export default function promiseMiddleware(config = {}) {
        */
       const getAction = (newPayload, isRejected) => ({
         type: `${type}_${isRejected ? REJECTED : FULFILLED}`,
-        ...newPayload ? { payload: newPayload } : {},
-        ...!!meta ? { meta } : {},
-        ...isRejected ? { error: true } : {}
+        ...(newPayload ? {
+          payload: newPayload
+        } : {}),
+        ...(!!meta ? { meta } : {}),
+        ...(isRejected ? {
+          error: true
+        } : {})
       });
 
       /**
@@ -70,8 +74,8 @@ export default function promiseMiddleware(config = {}) {
        */
       next({
         type: `${type}_${PENDING}`,
-        ...!!data ? { payload: data } : {},
-        ...!!meta ? { meta } : {}
+        ...(!!data ? { payload: data } : {}),
+        ...(!!meta ? { meta } : {})
       });
 
       /*

--- a/src/index.js
+++ b/src/index.js
@@ -41,13 +41,9 @@ export default function promiseMiddleware(config = {}) {
        */
       const getAction = (newPayload, isRejected) => ({
         type: `${type}_${isRejected ? REJECTED : FULFILLED}`,
-        ...newPayload ? {
-          payload: newPayload
-        } : {},
+        ...newPayload ? { payload: newPayload } : {},
         ...!!meta ? { meta } : {},
-        ...isRejected ? {
-          error: true
-        } : {}
+        ...isRejected ? { error: true } : {}
       });
 
       /**


### PR DESCRIPTION
This might be dumb edit, but I think keeping the ternary operators on a single line makes it a lot more readable. I thought about throwing in some extra parens as well to make it more obvious that you're assigning the properties of each resulting object into the return object and making the `...!!` a little more distinct as _two_ operations, because as an intermediate dev this threw me for a minutes. 

`...(!!meta ? { meta } : {}),`

vs. 

`...!!meta ? { meta } : {},`

Not sure if 'readability for average joes' is something you'd care about spending a few extra characters on though.