### PR TITLE
Allow payloads of `0` or `false`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,9 @@ export default function promiseMiddleware(config = {}) {
        */
       const getAction = (newPayload, isRejected) => ({
         type: `${type}_${isRejected ? REJECTED : FULFILLED}`,
-        ...(newPayload ? {
+        ...((newPayload === null || typeof newPayload === 'undefined') ? {} : {
           payload: newPayload
-        } : {}),
+        }),
         ...(!!meta ? { meta } : {}),
         ...(isRejected ? {
           error: true

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -306,6 +306,118 @@ describe('Redux promise middleware:', () => {
       });
     });
 
+    context('When resolve reason is false:', () => {
+      const falseResolveAction = {
+        type: defaultPromiseAction.type,
+        payload: Promise.resolve(false)
+      };
+
+      it('resolved action is dispatched', done => {
+        const actionDispatched = store.dispatch(falseResolveAction);
+
+        actionDispatched.then(
+          ({ value, action }) => {
+            expect(action).to.eql({
+              type: `${falseResolveAction.type}_FULFILLED`,
+              payload: false
+            });
+            done();
+          },
+          () => {
+            expect(true).to.equal(false); // Expect this is not called
+          }
+        );
+      });
+
+      it('promise returns `false` value', done => {
+        const actionDispatched = store.dispatch(falseResolveAction);
+
+        actionDispatched.then(
+          ({ value, action }) => {
+            expect(value).to.be.false;
+            done();
+          },
+          () => {
+            expect(true).to.equal(false); // Expect this is not called
+          }
+        );
+      });
+
+      /**
+       * If the resolved promise value is false, then there should still be a
+       * payload on the dispatched resolved action.
+       */
+      it('resolved action `payload` property is false', done => {
+        const actionDispatched = store.dispatch(falseResolveAction);
+
+        actionDispatched.then(
+          ({ value, action }) => {
+            expect(action.payload).to.be.false;
+            done();
+          },
+          () => {
+            expect(true).to.equal(false); // Expect this is not called
+          }
+        );
+      });
+    });
+
+    context('When resolve reason is zero:', () => {
+      const zeroResolveAction = {
+        type: defaultPromiseAction.type,
+        payload: Promise.resolve(0)
+      };
+
+      it('resolved action is dispatched', done => {
+        const actionDispatched = store.dispatch(zeroResolveAction);
+
+        actionDispatched.then(
+          ({ value, action }) => {
+            expect(action).to.eql({
+              type: `${zeroResolveAction.type}_FULFILLED`,
+              payload: 0
+            });
+            done();
+          },
+          () => {
+            expect(true).to.equal(false); // Expect this is not called
+          }
+        );
+      });
+
+      it('promise returns `0` value', done => {
+        const actionDispatched = store.dispatch(zeroResolveAction);
+
+        actionDispatched.then(
+          ({ value, action }) => {
+            expect(value).to.eq(0);
+            done();
+          },
+          () => {
+            expect(true).to.equal(false); // Expect this is not called
+          }
+        );
+      });
+
+      /**
+       * If the resolved promise value is zero, then there should still be a
+       * payload on the dispatched resolved action.
+       */
+      it('resolved action `payload` property is zero', done => {
+        const actionDispatched = store.dispatch(zeroResolveAction);
+
+        actionDispatched.then(
+          ({ value, action }) => {
+            expect(action.payload).to.eq(0);
+            done();
+          },
+          () => {
+            expect(true).to.equal(false); // Expect this is not called
+          }
+        );
+      });
+    });
+
     it('persists `meta` property from original action', async () => {
       await store.dispatch({
         type: promiseAction.type,


### PR DESCRIPTION
When a Promise resolves with a value of `0` or `false`, include that value as the `payload` property of the `FULFILLED` action.

The existing code omits the payload if it is any “falsy” value, which includes `null`, `undefined`, `0`, and `false`.

With this change, `null` and `undefined` payloads are still omitted, but `0` and `false` payloads are passed along with the `FULFILLED` action.

A slightly more idiomatic check for a `null` or `undefined` payload would be `newPayload == null`, but that is disallowed by the lint configuration.

I’ve added new specs for these cases, but they’re very similar to each other and have a fair bit of duplication with the `null` spec.  I wasn’t sure what you might want to do to clean that up.