### PR TITLE
Update action description for optimistic updates example

### DIFF
--- a/docs/guides/optimistic-updates.md
+++ b/docs/guides/optimistic-updates.md
@@ -18,8 +18,6 @@ Considering the action creator above, the pending action would be described as:
 // pending action
 {
   type: 'FOO_PENDING',
-  payload: {
-    data: ...
-  }
+  payload: data
 }
 ```


### PR DESCRIPTION
The docs previously seemed to indicate that the action dispatched for `FOO_PENDING` would have a `data` key nested under `payload`, whereas the `payload` key actually references `data` from the original action directly.