### PR TITLE
Fix handling of falsy data and meta

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ export default function promiseMiddleware(config = {}) {
         ...((newPayload === null || typeof newPayload === 'undefined') ? {} : {
           payload: newPayload
         }),
-        ...(!!meta ? { meta } : {}),
+        ...(meta !== undefined ? { meta } : {}),
         ...(isRejected ? {
           error: true
         } : {})
@@ -64,7 +64,7 @@ export default function promiseMiddleware(config = {}) {
         data = payload.data;
       } else {
         promise = payload;
-        data = null;
+        data = undefined;
       }
 
       /**
@@ -74,8 +74,8 @@ export default function promiseMiddleware(config = {}) {
        */
       next({
         type: `${type}_${PENDING}`,
-        ...(!!data ? { payload: data } : {}),
-        ...(!!meta ? { meta } : {})
+        ...(data !== undefined ? { payload: data } : {}),
+        ...(meta !== undefined ? { meta } : {})
       });
 
       /*

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -182,8 +182,9 @@ describe('Redux promise middleware:', () => {
         ...pendingAction,
         payload: optimisticUpdateData
       });
+    });
 
-      // Test handling of falsy data in particular.
+    it('pending action optionally contains falsy optimistic update payload', () => {
       store.dispatch({
         type: promiseAction.type,
         payload: {
@@ -201,7 +202,7 @@ describe('Redux promise middleware:', () => {
      * If the promise action is dispatched with a meta property, the meta property
      * and value must be included in the pending action.
      */
-    it('pending action does contains meta property if included', () => {
+    it('pending action does contain meta property if included', () => {
       store.dispatch(Object.assign({}, promiseAction, {
         meta: metaData
       }));
@@ -210,8 +211,9 @@ describe('Redux promise middleware:', () => {
           meta: metaData
         })
       );
+    });
 
-      // Test handling of falsy meta in particular.
+    it('pending action does contain falsy meta property if included', () => {
       store.dispatch(Object.assign({}, promiseAction, {
         meta: 0
       }));

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -182,6 +182,19 @@ describe('Redux promise middleware:', () => {
         ...pendingAction,
         payload: optimisticUpdateData
       });
+
+      // Test handling of falsy data in particular.
+      store.dispatch({
+        type: promiseAction.type,
+        payload: {
+          promise: promiseAction.payload,
+          data: 0
+        }
+      });
+      expect(lastMiddlewareModfies.spy).to.have.been.calledWith({
+        ...pendingAction,
+        payload: 0
+      });
     });
 
     /**
@@ -195,6 +208,16 @@ describe('Redux promise middleware:', () => {
       expect(lastMiddlewareModfies.spy).to.have.been.calledWith(
         Object.assign({}, pendingAction, {
           meta: metaData
+        })
+      );
+
+      // Test handling of falsy meta in particular.
+      store.dispatch(Object.assign({}, promiseAction, {
+        meta: 0
+      }));
+      expect(lastMiddlewareModfies.spy).to.have.been.calledWith(
+        Object.assign({}, pendingAction, {
+          meta: 0
         })
       );
     });


### PR DESCRIPTION
Falsy data (e.g., `data: 0`) and falsy meta properties aren't preserved by the middleware, even though FSA allows payload and meta to be anything, due to the use of `!!data` and `!!meta`.  This commit fixes this by changing the handling to a more restrictive `!== undefined`.