### PR TITLE
Export default promise status

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -39,7 +39,7 @@ A "pending" action is dispatched immediately with the original type string and a
 }
 ```
 
-After the promise is settled, a second action will be dispatched. If the the promise is resolved, e.g., if it was successful, a "fulfilled" action is dispatched. If the promise is rejected, e.g., if an error occurred, the "rejected" action is dispatched. The fulfilled and rejected type suffixes are `_FULFILLED` and `_REJECTED` respectively. The middleware will *always* dispatch one of these two actions.
+After the promise is settled, a second action will be dispatched. If the promise is resolved, e.g., if it was successful, a "fulfilled" action is dispatched. If the promise is rejected, e.g., if an error occurred, the "rejected" action is dispatched. The fulfilled and rejected type suffixes are `_FULFILLED` and `_REJECTED` respectively. The middleware will *always* dispatch one of these two actions.
 
 ```js
 // fulfilled action

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -65,3 +65,5 @@ The default promise status suffix can be imported from this module.
 ```js
 import { PENDING, FULFILLED, REJECTED } from 'redux-promise-middleware'
 ```
+
+If you use [custom suffixes](https://github.com/pburtchaell/redux-promise-middleware/blob/master/docs/guides/custom-suffixes.md) you need to create your own export variables. 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -59,3 +59,9 @@ After the promise is settled, a second action will be dispatched. If the the pro
   }
 }
 ```
+
+The default promise status suffix can be imported from this module.
+
+```js
+import { PENDING, FULFILLED, REJECTED } from 'redux-promise-middleware'
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import isPromise from './isPromise';
 
-export const DEFAULT_PENDING = 'PENDING';
-export const DEFAULT_FULFILLED = 'FULFILLED';
-export const DEFAULT_REJECTED = 'REJECTED';
+export const PENDING = 'PENDING';
+export const FULFILLED = 'FULFILLED';
+export const REJECTED = 'REJECTED';
 
-const defaultTypes = [DEFAULT_PENDING, DEFAULT_FULFILLED, DEFAULT_REJECTED];
+const defaultTypes = [PENDING, FULFILLED, REJECTED];
 
 /**
  * @function promiseMiddleware

--- a/src/index.js
+++ b/src/index.js
@@ -31,9 +31,9 @@ export default function promiseMiddleware(config = {}) {
 
       // Assign values for promise type suffixes
       const [
-        PENDING,
-        FULFILLED,
-        REJECTED
+        _PENDING,
+        _FULFILLED,
+        _REJECTED
       ] = promiseTypeSuffixes;
 
       /**
@@ -44,7 +44,7 @@ export default function promiseMiddleware(config = {}) {
        * @returns {object} action
        */
       const getAction = (newPayload, isRejected) => ({
-        type: `${type}_${isRejected ? REJECTED : FULFILLED}`,
+        type: `${type}_${isRejected ? _REJECTED : _FULFILLED}`,
         ...((newPayload === null || typeof newPayload === 'undefined') ? {} : {
           payload: newPayload
         }),
@@ -77,7 +77,7 @@ export default function promiseMiddleware(config = {}) {
        * (for optimistic updates) and/or meta from the original action.
        */
       next({
-        type: `${type}_${PENDING}`,
+        type: `${type}_${_PENDING}`,
         ...(data !== undefined ? { payload: data } : {}),
         ...(meta !== undefined ? { meta } : {})
       });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 import isPromise from './isPromise';
 
-const defaultTypes = ['PENDING', 'FULFILLED', 'REJECTED'];
+export const DEFAULT_PENDING = 'PENDING';
+export const DEFAULT_FULFILLED = 'FULFILLED';
+export const DEFAULT_REJECTED = 'REJECTED';
+
+const defaultTypes = [DEFAULT_PENDING, DEFAULT_FULFILLED, DEFAULT_REJECTED];
 
 /**
  * @function promiseMiddleware

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,7 +2,7 @@
 import Bluebird from 'bluebird';
 import { createStore, applyMiddleware } from 'redux';
 import configureStore from 'redux-mock-store';
-import promiseMiddleware from '../src/index';
+import promiseMiddleware, { DEFAULT_PENDING, DEFAULT_FULFILLED, DEFAULT_REJECTED } from '../src/index';
 
 describe('Redux Promise Middleware:', () => {
   let store;
@@ -39,6 +39,12 @@ describe('Redux Promise Middleware:', () => {
   };
 
   const nextHandler = promiseMiddleware();
+
+  it('must export correct default promise status', () => {
+    chai.assert.equal(DEFAULT_PENDING, 'PENDING');
+    chai.assert.equal(DEFAULT_FULFILLED, 'FULFILLED');
+    chai.assert.equal(DEFAULT_REJECTED, 'REJECTED');
+  });
 
   it('must return a function to handle next', () => {
     chai.assert.isFunction(nextHandler);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,7 +2,7 @@
 import Bluebird from 'bluebird';
 import { createStore, applyMiddleware } from 'redux';
 import configureStore from 'redux-mock-store';
-import promiseMiddleware, { DEFAULT_PENDING, DEFAULT_FULFILLED, DEFAULT_REJECTED } from '../src/index';
+import promiseMiddleware, { PENDING, FULFILLED, REJECTED } from '../src/index';
 
 describe('Redux Promise Middleware:', () => {
   let store;
@@ -41,9 +41,9 @@ describe('Redux Promise Middleware:', () => {
   const nextHandler = promiseMiddleware();
 
   it('must export correct default promise status', () => {
-    chai.assert.equal(DEFAULT_PENDING, 'PENDING');
-    chai.assert.equal(DEFAULT_FULFILLED, 'FULFILLED');
-    chai.assert.equal(DEFAULT_REJECTED, 'REJECTED');
+    chai.assert.equal(PENDING, 'PENDING');
+    chai.assert.equal(FULFILLED, 'FULFILLED');
+    chai.assert.equal(REJECTED, 'REJECTED');
   });
 
   it('must return a function to handle next', () => {


### PR DESCRIPTION
You can now import the (currently three) default promise status:

```javascript
import { DEFAULT_PENDING, DEFAULT_FULFILLED, DEFAULT_REJECTED } from 'redux-promise-middleware'
```

Issue [#143](https://github.com/pburtchaell/redux-promise-middleware/issues/143).