### PR TITLE
Add a config for able dispatch state mechina action

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import isPromise from './isPromise.js';
 export const PENDING = 'PENDING';
 export const FULFILLED = 'FULFILLED';
 export const REJECTED = 'REJECTED';
+export const STATEMACHINE = Symbol('ASYNC_STATE_MACHINE');
 
 const defaultTypes = [PENDING, FULFILLED, REJECTED];
 
@@ -14,6 +15,7 @@ const defaultTypes = [PENDING, FULFILLED, REJECTED];
 export default function promiseMiddleware(config = {}) {
   const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypes;
   const promiseTypeSeparator = config.promiseTypeSeparator || '_';
+  const stateMachine = config.isOpenStateType
 
   return ref => {
     const { dispatch } = ref;
@@ -55,6 +57,18 @@ export default function promiseMiddleware(config = {}) {
         } : {})
       });
 
+	  /**
+	   * @function getStateAction
+	   * @description Utility function for creating a action about the action state
+	   * @param  {Boolean} isFetching now this action is fetching or end ?
+	   * @return {object}  action
+	   */
+	  const getStateAction = isFetching => ({
+		  type: STATEMACHINE,
+		  actionType: type,
+		  isFetching
+	  });
+
       /**
        * Assign values for promise and data variables. In the case the payload
        * is an object with a `promise` and `data` property, the values of those
@@ -83,6 +97,13 @@ export default function promiseMiddleware(config = {}) {
         ...(meta !== undefined ? { meta } : {})
       });
 
+	  /**
+	   * if had the Configuration will dispatch a `true` action, to tell user this action's type
+	   * is fetching data now. and on the end of the promise will dispatch the `false` action whether
+	   * the promise is rejected or fulfilled
+	   */
+	  if (stateMachine) {next(getStateAction(true))};
+
       /*
        * @function handleReject
        * @description Dispatch the rejected action and return
@@ -93,6 +114,8 @@ export default function promiseMiddleware(config = {}) {
        * @returns {object}
        */
       const handleReject = reason => {
+	  	if (stateMachine) {next(getStateAction(false))};
+
         const rejectedAction = getAction(reason, true);
         dispatch(rejectedAction);
 
@@ -108,6 +131,8 @@ export default function promiseMiddleware(config = {}) {
        * @returns {object}
        */
       const handleFulfill = (value = null) => {
+		if (stateMachine) {next(getStateAction(false))};
+
         const resolvedAction = getAction(value, false);
         dispatch(resolvedAction);
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const defaultTypes = [PENDING, FULFILLED, REJECTED];
 export default function promiseMiddleware(config = {}) {
   const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypes;
   const promiseTypeSeparator = config.promiseTypeSeparator || '_';
-  const stateMachine = config.isOpenStateType
+  const stateMachine = config.isOpenStateType;
 
   return ref => {
     const { dispatch } = ref;
@@ -57,17 +57,17 @@ export default function promiseMiddleware(config = {}) {
         } : {})
       });
 
-	  /**
-	   * @function getStateAction
-	   * @description Utility function for creating a action about the action state
-	   * @param  {Boolean} isFetching now this action is fetching or end ?
-	   * @return {object}  action
-	   */
-	  const getStateAction = isFetching => ({
-		  type: STATEMACHINE,
-		  actionType: type,
-		  isFetching
-	  });
+      /**
+       * @function getStateAction
+       * @description Utility function for creating a action about the action state
+       * @param  {Boolean} isFetching now this action is fetching or end ?
+       * @return {object}  action
+       */
+      const getStateAction = isFetching => ({
+        type: STATEMACHINE,
+        actionType: type,
+        isFetching
+      });
 
       /**
        * Assign values for promise and data variables. In the case the payload
@@ -97,12 +97,12 @@ export default function promiseMiddleware(config = {}) {
         ...(meta !== undefined ? { meta } : {})
       });
 
-	  /**
-	   * if had the Configuration will dispatch a `true` action, to tell user this action's type
-	   * is fetching data now. and on the end of the promise will dispatch the `false` action whether
-	   * the promise is rejected or fulfilled
-	   */
-	  if (stateMachine) {next(getStateAction(true))};
+      /**
+       * if had the Configuration will dispatch a `true` action, to tell user this action's type
+       * is fetching data now. and on the end of the promise will dispatch the `false` action
+       * whether the promise is rejected or fulfilled
+       */
+      if (stateMachine) { next(getStateAction(true)); }
 
       /*
        * @function handleReject
@@ -114,7 +114,7 @@ export default function promiseMiddleware(config = {}) {
        * @returns {object}
        */
       const handleReject = reason => {
-	  	if (stateMachine) {next(getStateAction(false))};
+        if (stateMachine) { next(getStateAction(false)); }
 
         const rejectedAction = getAction(reason, true);
         dispatch(rejectedAction);
@@ -131,7 +131,7 @@ export default function promiseMiddleware(config = {}) {
        * @returns {object}
        */
       const handleFulfill = (value = null) => {
-		if (stateMachine) {next(getStateAction(false))};
+        if (stateMachine) { next(getStateAction(false)); }
 
         const resolvedAction = getAction(value, false);
         dispatch(resolvedAction);


### PR DESCRIPTION
My english is not good, please forgive these poor English below. 🙏

in my work ,In order to optimistic updates, i have to create many variable  for  such as `xxx loading`、`xxx fetching`, it is Tedious and Unmanageable. just like this

```javascript
switch (action.type) {
	case 'MY_ACTION_TYPE_PENDING':
		return {...state, loading: true}
	case 'MY_ACTION_TYPE_FULFILLED':
		return {...state, xxx,  loading: false}
	case 'MY_ACTION_TYPE_REJECTED':
		return {...state, loading: false}
}
```

so i want add a configuration items.once you open this configuration, every action that deal with this middleware will dispatch `state mechina action` with params `actionType `,  `isFetching` on the Asynchronous request start and end .

i can create a reducer to deal with the action like this

```javascript
import { STATEMACHINE } from 'redux-promise-middleware'

const uiState = (state = {}, action) => {
	switch (action.type) {
		case STATEMACHINE: {
			let { actionType, isFetching } = action
			return {
				...state,
				[actionType]: isFetching
			}
		}
		default:
			return state
	}
}
```

after this i can manage the state like this

```javascript
<Button 
      loading={this.props.isLoading} />

...

const mapStateToProps = state => ({
    ...,
    isLoading: state.uiState.MY_ACTION_TYPE
})

```
