### PR TITLE
improvement on promiseTypeSeparator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const defaultTypes = [PENDING, FULFILLED, REJECTED];
  */
 export default function promiseMiddleware(config = {}) {
   const promiseTypeSuffixes = config.promiseTypeSuffixes || defaultTypes;
-  const promiseTypeSeparator = config.promiseTypeSeparator || '_';
+  const promiseTypeSeparator = config.promiseTypeSeparator !== undefined ? config.promiseTypeSeparator : '_';
 
   return ref => {
     const { dispatch } = ref;


### PR DESCRIPTION
Hi:

I created this PR because I tried to use the original EVENT name to fulfilled step, but I can't. 
This is an example:

``` javascript
export default applyMiddleware(
    promise({
        /* use original EVENT by fulfilled case */
        promiseTypeSuffixes: ['_PENDING', '', '_REJECTED'],
        promiseTypeSeparator: ''
    }),
    ...
)
```

This way, when create an action like this:

```javascript
export const addTweet = (text) => ({
    type: 'ADD_TWEET',
    payload: new Promise((resolve, reject) => {
        try {
            getSocket().emit('add:tweet', { text },
                /* callback with data generated on backend */
                (err, tweet) => {
                    if (err) reject(err);
                    else resolve(tweet);
                })
        } catch (err) {
            reject(err);
        }
    })
})
``` 

Its Reduce could be:
```javascript
{
    'ADD_TWEET_PENDING': (state, action) => ({
        ...state,
        sending: true
    }),
    /* not ADD_TWEET_FULFILLED */
    'ADD_TWEET': (state, action) => ({
        ...state,
        sending: false,
        tweets: [...state.tweets, action.payload],
    }),
    'ADD_TWEET_REJECTED': (state, action) => ({
        ...state,
        sending: false,
        error: action.payload
    }),
}
```

That small change is very useful, in cases when receive (through socket i.e.) directly a data from server, and it's necessary use the same reducer than when send data directly to server. Like this example:

```javascript
getSocket().on('add:tweet', (payload) => {
    getStore().dispatch({
        type: 'ADD_TWEET',
        payload
    })
})
```

Instance of
```javascript
getSocket().on('add:tweet', (payload) => {
    getStore().dispatch({
        type: 'ADD_TWEET_FULFILLED',
        payload
    })
})
```

Regards

Carlos D. Iglesias
