### PR TITLE
[Enhancement] Preserving all props of action instead of just meta

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -63,12 +63,26 @@ On the other hand, if the promise is rejected, a rejected action is dispatched.
 
 That's it!
 
+It is also possible to carry additional data through the stages of the action lifecycle. Any properties of the action object will be preserved except the 3 "reserved" properties ("type", "payload" and "error")
+
+```js
+{
+  type: 'FOO',
+  payload: new Promise(),
+  myCustomProperty: {
+    subProp1: 1,
+    subProp2: 'BAR'
+  }
+}
+```
+
 ## Further Reading
 
-- [Catching Errors Thrown by Rejected Promises](guides/rejected-promises.md)
-- [Use with Reducers](guides/reducers.md)
-- [Optimistic Updates](guides/optimistic-updates.md)
-- [Design Principles](guides/design-principles.md)
+* [Catching Errors Thrown by Rejected Promises](guides/rejected-promises.md)
+* [Use with Reducers](guides/reducers.md)
+* [Optimistic Updates](guides/optimistic-updates.md)
+* [Design Principles](guides/design-principles.md)
 
 ---
+
 Copyright (c) 2017 Patrick Burtchaell. [Code licensed with the MIT License (MIT)](/LICENSE). [Documentation licensed with the CC BY-NC License](LICENSE).


### PR DESCRIPTION
Hi,

this PR enables this middleware to keep all properties of the action object instead of just meta. I was looking for this possibility without knowing the "meta" property already exist until I read the source. So it solved my case but I thought I throw in the idea of not just limiting the action object to "type", "payload", "error" and "meta" but preserving all props of the input action except the 3 "reserved" to work with.

I'd like to know what you think of this. I'm not having a routine of creating PRs so if anything is missing or wrong, please let me know. I also created some additional tests and modified the introduction file to document the feature.

best regards,
Sebastian