### PR TITLE
Create Typescript Definitions

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -82,6 +82,10 @@ const foo = () => ({
 
 That's it!
 
+## TypeScript
+
+`redux-promise-middleware` also supports TypeScript.
+
 ## Further Reading
 
 - [Catching Errors Thrown by Rejected Promises](guides/rejected-promises.md)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+import { Middleware } from 'redux';
+
+export declare const PENDING: string;
+export declare const FULFILLED: string;
+export declare const REJECTED: string;
+
+declare function promiseMiddleware(config?: { promiseTypeSuffixes?: string[], promiseTypeDelimiter?: string }): Middleware;
+
+export default promiseMiddleware;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import isPromise from './isPromise.js';
 
 /**
- * Note to contributors: Please also remember to check and make sure 
- * that `index.d.ts` is also up to date with the implementation when 
+ * Note to contributors: Please also remember to check and make sure
+ * that `index.d.ts` is also up to date with the implementation when
  * you add new features or modify existing ones.
  */
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
 import isPromise from './isPromise.js';
 
+/**
+ * Note to contributors: Please also remember to check and make sure that `index.d.ts` is also up to date with
+ * the implementation when you add new features or modify existing ones.
+ */
+
 // The default async action types
 export const PENDING = 'PENDING';
 export const FULFILLED = 'FULFILLED';

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import isPromise from './isPromise.js';
 
 /**
- * Note to contributors: Please also remember to check and make sure that `index.d.ts` is also up to date with
- * the implementation when you add new features or modify existing ones.
+ * Note to contributors: Please also remember to check and make sure 
+ * that `index.d.ts` is also up to date with the implementation when 
+ * you add new features or modify existing ones.
  */
 
 // The default async action types


### PR DESCRIPTION
Create Typescript Definitions.
There already exists one under `@types/`, but that one was not updated for a while and does not match the implementation. It also doesn't include types for `PENDING`/`FULFILLED`/`REJECTED` consts.