### PR TITLE
Allow redux 4 in peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2182,6 +2182,12 @@
         "mimic-response": "1.0.0"
       }
     },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=",
+      "dev": true
+    },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
@@ -6976,15 +6982,22 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5",
-        "lodash-es": "4.17.5",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.2.0"
+      }
+    },
+    "redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "dev": true,
+      "requires": {
+        "deep-diff": "0.3.8"
       }
     },
     "redux-mock-store": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react-dom": "^15.5.4",
     "react-redux": "^5.0.5",
     "react-router": "3.0.5",
-    "redux": "^3.0.4",
+    "redux": "^4.0.0",
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.2.2",
     "redux-thunk": "^2.0.1",
@@ -89,6 +89,6 @@
     "webpack-hot-middleware": "^2.18.0"
   },
   "peerDependencies": {
-    "redux": "^2.0.0 || ^3.0.0"
+    "redux": "^2.0.0 || ^3.0.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
Allows to use Redux 4.

Tests pass, and my application works as before.

The complex example does not work, but it did not before this change either.
