### PR TITLE
Realizing the issue #219 Consider Changing Public API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,13 +18,20 @@ const defaultTypes = [PENDING, FULFILLED, REJECTED];
  * object and returns the middleware.
  */
 export default function promiseMiddleware(config = {}) {
-  const PROMISE_TYPE_SUFFIXES = config.promiseTypeSuffixes || defaultTypes;
-  const PROMISE_TYPE_DELIMITER = config.promiseTypeDelimiter || '_';
+  let { dispatch, promiseTypeSuffixes, promiseTypeDelimiter } = config;
+
+  const PROMISE_TYPE_SUFFIXES = promiseTypeSuffixes || defaultTypes;
+  const PROMISE_TYPE_DELIMITER = promiseTypeDelimiter || '_';
+
+  if(dispatch && typeof dispatch === 'function') return fn;
 
   return ref => {
-    const { dispatch } = ref;
+    dispatch = ref.dispatch;
+    return fn;
+  }
 
-    return next => action => {
+  function fn(next) {
+    return action => {
 
       /**
        * Instantiate variables to hold:
@@ -202,5 +209,5 @@ export default function promiseMiddleware(config = {}) {
        */
       return promise.then(handleFulfill, handleReject);
     };
-  };
+  }
 }


### PR DESCRIPTION
Hello! :wave: 

When applying the middleware to my Redux store, I need to first call the promiseMiddleware() method, which returns the middleware. It's diifferent from other Redux middleware APIs. 

Yes, the API should support custom configuration, but I also think we could simplify the API.

Default API:
```
import thunk from 'redux-thunk';
import promise from 'redux-promise-middleware';
import logger from 'redux-logger';

const store = createStore(reducers, null, applyMiddleware(
  thunk,
  promise,
  logger,
));
```

Custom middleware API:
```
import thunk from 'redux-thunk';
import { createPromise } from 'redux-promise-middleware';
import { createLogger } from 'redux-logger';

const store = createStore(reducers, null, applyMiddleware(
  thunk,
  createPromise(myConfigObject),
  createLogger(myLoggerConfigObject),
));
```