### PR TITLE
Refactor Public API

### DIFF
--- a/docs/guides/custom-suffixes.md
+++ b/docs/guides/custom-suffixes.md
@@ -1,10 +1,12 @@
 # Type Suffix Configuration
 
-In the case you need to use different type suffixes, you can configure this globally for all actions or locally (action-by-action).
+In the case you need to use different type suffixes, you can configure this globally for all actions or locally (action-by-action) using the exported function `createPromise`.
 
-To change suffixes, you can supply an optional configuration object to the middleware. This object accepts an array of suffix strings that can be used instead of the default with a key of `promiseTypeSuffixes`.
+To change suffixes, you can supply an optional configuration object to `createPromise`. This object accepts an array of suffix strings that can be used instead of the default with a key of `promiseTypeSuffixes`.
 
 ```js
+import { createPromise } from 'redux-promise-middleware'
+
 applyMiddleware(
   promiseMiddleware({
     promiseTypeSuffixes: ['LOADING', 'SUCCESS', 'ERROR']

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -22,7 +22,7 @@ Import the middleware and include it in `applyMiddleware` when creating the Redu
 import promiseMiddleware from 'redux-promise-middleware'
 
 composeStoreWithMiddleware = applyMiddleware(
-  promiseMiddleware(),
+  promiseMiddleware,
 )(createStore)
 ```
 
@@ -90,4 +90,5 @@ The middleware does support TypeScript.
 - [Catching Errors Thrown by Rejected Promises](guides/rejected-promises.md)
 - [Use with Reducers](guides/reducers.md)
 - [Optimistic Updates](guides/optimistic-updates.md)
+- [Custom Types](guides/custom-suffixes.md)
 - [Design Principles](guides/design-principles.md)

--- a/examples/catching-errors-with-middleware/store.js
+++ b/examples/catching-errors-with-middleware/store.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
-import promiseMiddleware from '../../src';
+import promise from '../../src';
 import errorMiddleware from './middleware';
 import { createLogger } from 'redux-logger';
 
@@ -8,7 +8,7 @@ const reducer = (state) => state;
 // Custom error middleware should go before the promise middleware
 const store = createStore(reducer, null, applyMiddleware(
   errorMiddleware,
-  promiseMiddleware(),
+  promise,
   createLogger({ collapsed: true }),
 ));
 

--- a/examples/catching-errors/store.js
+++ b/examples/catching-errors/store.js
@@ -8,7 +8,7 @@ const reducer = (state) => state;
 // Custom error middleware should go before the promise middleware
 const store = createStore(reducer, null, applyMiddleware(
   thunk,
-  promise(),
+  promise,
   createLogger({ collapsed: true }),
 ));
 

--- a/examples/using-promise-actions/store.js
+++ b/examples/using-promise-actions/store.js
@@ -14,7 +14,7 @@ import { getDog } from './actions';
 const reducer = asyncReducer(getDog);
 
 const store = createStore(reducer, {}, applyMiddleware(
-  promise(),
+  promise,
   createLogger({ collapsed: true }),
 ));
 

--- a/examples/using-promise-all/store.js
+++ b/examples/using-promise-all/store.js
@@ -1,7 +1,7 @@
 import { createStore, applyMiddleware } from 'redux';
-import promise from '../../src/index';
 import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
+import promise from '../../src/index';
 
 const defaultState = {
   images: [],

--- a/examples/using-promise-all/store.js
+++ b/examples/using-promise-all/store.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
-import promiseMiddleware from '../../src/index';
+import promise from '../../src/index';
 import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
 
@@ -21,7 +21,7 @@ const reducer = (state = defaultState, action) => {
 
 const store = createStore(reducer, {}, applyMiddleware(
   thunk,
-  promiseMiddleware(),
+  promise,
   createLogger({ collapsed: true }),
 ));
 

--- a/examples/using-promise-middleware/store.js
+++ b/examples/using-promise-middleware/store.js
@@ -22,7 +22,7 @@ const reducer = (state = defaultState, action) => {
 };
 
 const store = createStore(reducer, {}, applyMiddleware(
-  promise(),
+  promise,
   createLogger({ collapsed: true }),
 ));
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,11 @@ export const REJECTED = 'REJECTED';
 const defaultTypes = [PENDING, FULFILLED, REJECTED];
 
 /**
- * Function: promiseMiddleware
- * Description: The main promiseMiddleware accepts a configuration
+ * Function: createPromise
+ * Description: The main createPromise accepts a configuration
  * object and returns the middleware.
  */
-export default function promiseMiddleware(config = {}) {
+export function createPromise(config = {}) {
   const PROMISE_TYPE_SUFFIXES = config.promiseTypeSuffixes || defaultTypes;
   const PROMISE_TYPE_DELIMITER = config.promiseTypeDelimiter || '_';
 
@@ -203,4 +203,25 @@ export default function promiseMiddleware(config = {}) {
       return promise.then(handleFulfill, handleReject);
     };
   };
+}
+
+
+// eslint-disable-next-line consistent-return
+export default function promiseMiddleware({ dispatch } = {}) {
+
+  if (typeof dispatch === 'function') {
+    return createPromise()({ dispatch });
+  }
+
+  // eslint-disable-next-line no-console
+  console.error(`
+    [redux-promise-middleware] BREAKING CHANGE
+    [redux-promise-middleware] The current version redux-promise-middleware exports
+    [redux-promise-middleware] the promiseMiddleware with default settings.
+    [redux-promise-middleware] If you want to get a promiseMiddleware with custom config, 
+    [redux-promise-middleware] please change
+    [redux-promise-middleware] import createPromise from 'redux-promise-middleware'
+    [redux-promise-middleware] to
+    [redux-promise-middleware] import { createPromise } from 'redux-promise-middleware'
+  `);
 }

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -1,4 +1,6 @@
-import promise, { createPromise, PENDING, FULFILLED, REJECTED } from 'redux-promise-middleware';
+import promise, {
+    createPromise, PENDING, FULFILLED, REJECTED
+} from 'redux-promise-middleware';
 
 const middleware = createPromise();
 

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -1,9 +1,13 @@
-import promiseMiddleware, { PENDING, FULFILLED, REJECTED } from 'redux-promise-middleware';
+import promise, { createPromise, PENDING, FULFILLED, REJECTED } from 'redux-promise-middleware';
 
-const middleware = promiseMiddleware();
+const middleware = createPromise();
 
 test('module exports function', () => {
   expect(middleware.length).toBe(1);
+});
+
+test('module exports middleware with defaults', () => {
+  expect(promise.length).toBe(0);
 });
 
 test('module exports promise types', () => {

--- a/test/utils/createStore.js
+++ b/test/utils/createStore.js
@@ -1,5 +1,5 @@
 import { createStore as createReduxStore, applyMiddleware } from 'redux';
-import promiseMiddleware from 'redux-promise-middleware';
+import { createPromise } from 'redux-promise-middleware';
 import spyMiddleware from './spyMiddleware';
 
 /*
@@ -13,7 +13,7 @@ const createStore = (config, restMiddlewares = []) => {
 
   const middlewares = [
     spyMiddleware(firstSpy),
-    promiseMiddleware(config),
+    createPromise(config),
     spyMiddleware(lastSpy),
     ...restMiddlewares,
   ];


### PR DESCRIPTION
Hello! :wave: 

Re-opening a PR for issue #219.
- Refactor public API to support a default config middleware and the ability to configure the middleware. This is more in line with other middlewares.
- Move current API to `createPromise` function
- Default export a function with default configuration

Default API:
```js
import thunk from 'redux-thunk';
import promise from 'redux-promise-middleware';
import logger from 'redux-logger';

const store = createStore(reducers, null, applyMiddleware(
  thunk,
  promise,
  logger,
));
```

Custom middleware API:

```js
import thunk from 'redux-thunk';
import { createPromise } from 'redux-promise-middleware';
import { createLogger } from 'redux-logger';

const store = createStore(reducers, null, applyMiddleware(
  thunk,
  createPromise(myConfigObject),
  createLogger(myLoggerConfigObject),
));
```