### PR TITLE
Fix npmignore for TS definitions

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ test/
 .npmignore
 .travis.yml
 webpack.config.js
+!src/index.d.ts

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "redux-promise-middleware",
   "description": "Enables simple, yet robust handling of async action creators in Redux",
-  "version": "6.0.1-beta.0",
+  "version": "6.0.1",
   "main": "dist/index.js",
   "types": "src/index.d.ts",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "redux-promise-middleware",
   "description": "Enables simple, yet robust handling of async action creators in Redux",
-  "version": "6.0.0",
+  "version": "6.0.1-beta.0",
   "main": "dist/index.js",
   "types": "src/index.d.ts",
   "module": "dist/es/index.js",


### PR DESCRIPTION
Includes `index.d.ts` when publishing to npm.

Connect #236.