### PR TITLE
fix wrong import in upgrade to v6 docs

### DIFF
--- a/docs/upgrading/v6.md
+++ b/docs/upgrading/v6.md
@@ -45,7 +45,7 @@ applyMiddleware(
 )(createStore)
 ```
 
-## New: `ActionType` Export
+## New: `ActionTypes` Export
 
 ### Before
 
@@ -75,7 +75,7 @@ This is a nice affordance, it could be better design if the action types were ex
 ### After
 
 ```js
-import { ActionType } from 'redux-promise-middleware'
+import { ActionTypes } from 'redux-promise-middleware'
 ```
 
 Now, the action types are exported as one enum.
@@ -83,13 +83,13 @@ Now, the action types are exported as one enum.
 ```js
 const reducer = (state = {}, action) => {
   switch(action.type) {
-    case `FOO_${ActionType.Pending}`:
+    case `FOO_${ActionTypes.Pending}`:
       // ..
 
-    case `FOO_${ActionType.Fulfilled}`:
+    case `FOO_${ActionTypes.Fulfilled}`:
       // ...
 
-    case `FOO_${ActionType.Rejected}`:
+    case `FOO_${ActionTypes.Rejected}`:
       // ...
 
     default: return state;


### PR DESCRIPTION
Just fixed import of ActionTypes in documentation. (use ActionTypes instead of ActionType)