### PR TITLE
Fix typo in reducers guide

### DIFF
--- a/docs/guides/reducers.md
+++ b/docs/guides/reducers.md
@@ -45,9 +45,9 @@ import { ActionType } from 'redux-promise-middleware';
 This can be useful in your reducers to ensure types are more robust.
 
 ```js
-const FOO_PENDING = `FOO_${ActionTypes.Pending}`;
-const FOO_FULFILLED = `FOO_${ActionTypes.Fulfilled}`;
-const FOO_REJECTED = `FOO_${ActionTypes.Rejected}`;
+const FOO_PENDING = `FOO_${ActionType.Pending}`;
+const FOO_FULFILLED = `FOO_${ActionType.Fulfilled}`;
+const FOO_REJECTED = `FOO_${ActionType.Rejected}`;
 ```
 
 ## Large Applications


### PR DESCRIPTION
Correct import is `ActionType` but `ActionTypes` was being used.

Hello! :wave: 

This template enables you to open an issue that is valuable for you, the project, and the GitHub community. :two_hearts:

Before submitting an issue, please:
1. Agree the [Code of Conduct](/.github/CODE_OF_CONDUCT.md).
2. Read the [Contributing Guide](/.github/CONTRIBUTING.md).

If you are new to open source, check out this 38 minute course on [how to contribute to open source on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github). It's free! :smile:

---

Before submitting a pull request, please make sure the following is done:

1. Add tests for new functionality or bug fixes, following the [red/green/refactor method](https://en.wikipedia.org/wiki/Test-driven_development#Development_style)
2. Ensure all tests pass: `npm test`
3. Update and/or add documentation

**In order to merge your Pull Request, tests and documentation are required.** 