### PR TITLE
Fix the example

### DIFF
--- a/docs/guides/rejected-promises.md
+++ b/docs/guides/rejected-promises.md
@@ -21,7 +21,7 @@ This can be done by dispatching some specific action. Here's an example of handl
 
 ```js
 export function foo() {
-  return dispatch => dispatch({
+  return dispatch => ({
     type: 'FOO_ACTION',
 
     // Throw an error


### PR DESCRIPTION
The second `dispatch` is not needed and will throw a Type Error.