### PR TITLE
Fix removing warning from production build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ export default function middleware({ dispatch } = {}) {
     return createPromise()({ dispatch });
   }
 
-  if (process && process.env && (process.env.NODE_ENV === 'development' || 'test')) {
+  if (process && process.env && process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line no-console
     console.warn(`Redux Promise Middleware: As of version 6.0.0, the \
 middleware library supports both preconfigured and custom configured \


### PR DESCRIPTION
The current solution is not really working since after `webpack` replacement we end up with:
```
if (process && process.env && (false || 'test')) {
```
 whitch is alway `true` and this part of code is never removed from production build.