### PR TITLE
Added note about returning the inner dispatch

### DIFF
--- a/docs/guides/chaining-actions.md
+++ b/docs/guides/chaining-actions.md
@@ -2,14 +2,9 @@
 
 When a promise is resolved, one might want to dispatch additional actions in response. One example could be changing the route after a user is successfully signed in. Another could be showing an error message after a request fails.
 
-First, note this behavior uses thunks. You will need to include [Redux Thunk](https://github.com/gaearon/redux-thunk) in your middleware stack.
+First, note this behavior uses thunks. You will need to include [Redux Thunk](https://github.com/gaearon/redux-thunk) in your middleware stack. 
 
-Redux Thunk allows you to return a function instead of an action(object).
-Redux Thunk will automatically pass dispatch(and some more params) to this function and then call it<br>
-Note! even thought using Redux Thunk you are not obligated to return the inner dispatch,
-With redux-promise-middleware you must.
-The reason is that redux-promise-middleware actually returns the promise inside payload.
-That is very useful for chaining and testing
+*Note: Redux Thunk is a middleware enables action creators to return a function ([hence the name "thunk"](https://en.wikipedia.org/wiki/Thunk)) instead of an object. The returned function is called with a `dispatch` argument, which is what you can use to chain actions.*
 
 
 ```js

--- a/docs/guides/chaining-actions.md
+++ b/docs/guides/chaining-actions.md
@@ -4,6 +4,14 @@ When a promise is resolved, one might want to dispatch additional actions in res
 
 First, note this behavior uses thunks. You will need to include [Redux Thunk](https://github.com/gaearon/redux-thunk) in your middleware stack.
 
+Redux Thunk allows you to return a function instead of an action(object).
+Redux Thunk will automatically pass dispatch(and some more params) to this function and then call it<br>
+Note! even thought using Redux Thunk you are not obligated to return the inner dispatch,
+With redux-promise-middleware you must.
+The reason is that redux-promise-middleware actually returns the promise inside payload.
+That is very useful for chaining and testing
+
+
 ```js
 const foo = () => {
   return dispatch => {


### PR DESCRIPTION
I had an issue with my test
store.dispatch() wasn't tenable.
As we can see from  redux-thunk documentation https://github.com/reduxjs/redux-thunk, 
there is no obligation to return inner dispatch .
So I just wanted to clarify that in combination of 2 libraries it becomes a must.
It is not trivial to return the payload's promise as dispatch return value, so I just wanted to clarify that 

Then I saw this question in stack overflow : https://stackoverflow.com/questions/43986386/unit-testing-redux-async-actions/59655786#59655786
Related to this issue https://github.com/pburtchaell/redux-promise-middleware/issues/155
The problem in the code inside the issue that it doesn't returns the inner dispatch