### PR TITLE
Fix payload parameter in getAction util

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,9 +137,7 @@ export function createPromise(config = {}) {
         ].join(PROMISE_TYPE_DELIMITER),
 
         // Include the payload property.
-        ...((newPayload === null || typeof newPayload === 'undefined') ? {} : {
-          payload: newPayload
-        }),
+        payload: newPayload,
 
         // If the original action includes a meta property, include it.
         ...(META !== undefined ? { meta: META } : {}),

--- a/test/resolve-null.spec.js
+++ b/test/resolve-null.spec.js
@@ -31,7 +31,7 @@ describe('given a promise resolved with a null value', () => {
 
     action.then(({ value, action: actionFromPromise }) => {
       expect(value).toEqual(null);
-      expect(actionFromPromise.payload).toEqual(undefined);
+      expect(actionFromPromise.payload).toEqual(null);
       done();
     });
   });

--- a/test/utils/defaults.js
+++ b/test/utils/defaults.js
@@ -136,7 +136,7 @@ const actions = {
   }),
   [types.FULFILLED_NULL_PROMISE]: () => ({
     type: `${defaultAction.type}_FULFILLED`,
-    payload: undefined,
+    payload: null,
   }),
   [types.FULFILLED_NUMBER_PROMISE]: () => ({
     type: `${defaultAction.type}_FULFILLED`,


### PR DESCRIPTION
This PR fixes the returned object of the `getAction` util. The returned object should contain a payload property.

**WIP**: Please see the referenced issue.

Closes https://github.com/pburtchaell/redux-promise-middleware/issues/262