### PR TITLE
Fix link to 5.x documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For help, [ask a question on StackOverflow](https://stackoverflow.com/questions/
 - [Upgrade from 3.x to 4.0.0](docs/upgrading/v4.md)
 
 For older versions:
-- [5.x](https://github.com/pburtchaell/redux-promise-middleware/tree/5.0.1)
+- [5.x](https://github.com/pburtchaell/redux-promise-middleware/tree/5.1.1)
 - [4.x](https://github.com/pburtchaell/redux-promise-middleware/tree/4.4.0)
 - [3.x](https://github.com/pburtchaell/redux-promise-middleware/tree/3.3.0)
 - [2.x](https://github.com/pburtchaell/redux-promise-middleware/tree/2.4.0)


### PR DESCRIPTION
The previous link to 5.0.1 was broken. Changing to 5.1.1 seems to fix it.