### PR TITLE
BUGFIX: An empty string value for promiseTypeDelimiter should not be …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,9 @@ export const ActionType = {
 export function createPromise(config = {}) {
   const defaultTypes = [ActionType.Pending, ActionType.Fulfilled, ActionType.Rejected];
   const PROMISE_TYPE_SUFFIXES = config.promiseTypeSuffixes || defaultTypes;
-  const PROMISE_TYPE_DELIMITER = config.promiseTypeDelimiter || '_';
+  const PROMISE_TYPE_DELIMITER = (
+    config.promiseTypeDelimiter === undefined ? '_' : config.promiseTypeDelimiter
+  );
 
   return ref => {
     const { dispatch } = ref;

--- a/test/delimiter.spec.js
+++ b/test/delimiter.spec.js
@@ -34,3 +34,21 @@ test('actions dispatched with custom delimiter', (done) => {
     done();
   });
 });
+
+// The middleware should allow empty string delimiter
+test('actions dispatched with custom delimiter', (done) => {
+  store = createStore({ promiseTypeDelimiter: '' });
+
+  const dispatched = getActionCreator(types.WILL_RESOLVE)();
+
+  const expected = {
+    ...getActionCreator(types.FULFILLED)(),
+    type: `${dispatched.type}FULFILLED`,
+  };
+
+  return store.dispatch(dispatched).then(({ value, action }) => {
+    expect(value).toEqual(expected.payload);
+    expect(action).toEqual(expected);
+    done();
+  });
+});


### PR DESCRIPTION
This fixes the issue #290  

promiseTypeDelimiter now respect empty string `''` value instead of replacing it with the default `'_'`