### PR TITLE
Correct promiseTypeDelimiter option name in upgrade docs

### DIFF
--- a/docs/upgrading/v6.md
+++ b/docs/upgrading/v6.md
@@ -40,7 +40,7 @@ import { createPromise } from 'redux-promise-middleware'
 applyMiddleware(
   createPromise({
     // Custom configuration
-    typeDelimiter: '/',
+    promiseTypeDelimiter: '/',
   }),
 )(createStore)
 ```


### PR DESCRIPTION
This pull request makes a small update to the documentation to reflect the correct configuration option name for the `createPromise` middleware.

- Updated the `docs/upgrading/v6.md` example to use `promiseTypeDelimiter` instead of the incorrect `typeDelimiter` option.